### PR TITLE
Use single api request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # W3C validator for Holberton School
-For HTML, XHTML, SVG and CSS files
+For HTML, CSS and SVG files
 
 Based on 1 API:
 - [Markup Validator Web Service API](https://validator.w3.org/docs/api.html)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # W3C validator for Holberton School
+For HTML, XHTML, SVG and CSS files
 
-For HTML and CSS files.
-
-Based on 2 APIs:
-
-[Markup Validator Web Service API](https://validator.w3.org/docs/api.html)
-[CSS Validator Web Service API](https://jigsaw.w3.org/css-validator/api.html)
+Based on 1 API:
+- [Markup Validator Web Service API](https://validator.w3.org/docs/api.html)
 
 ## Requirements
-[Python 3](https://www.python.org/downloads/)
-[Requests: HTTP for Humans™](https://requests.readthedocs.io/en/master/index.html)
+- [Python 3](https://www.python.org/downloads/)
+- [Requests: HTTP for Humans™](https://requests.readthedocs.io/en/master/index.html)
 
-You can install requests using pip:
+You can install Requests using pip:
 ```
 python 3 -m pip install requests
 ```
@@ -26,18 +23,22 @@ git clone https://github.com/holbertonschool/W3C-Validator.git
 
 2. Run shell script (see example in [usage](#usage) section below)
 
-## Usage:
+## Usage
 
-Simple file:
+Single file:
 
 ```sh
 ./w3c_validator.py index.html
 ```
 
+```sh
+./w3c_validator.py css/styles.css
+```
+
 Multiple files:
 
 ```sh
-./w3c_validator.py index.html header.html styles/common.css
+./w3c_validator.py index.html article.html css/styles.css
 ```
 
 All errors are printed in `STDERR`; Exit status = # of errors (0 on success)

--- a/README.md
+++ b/README.md
@@ -8,22 +8,13 @@ Based on 1 API:
 - [Python 3](https://www.python.org/downloads/)
 - [Requests: HTTP for Humans™](https://requests.readthedocs.io/en/master/index.html)
 
-You can install Requests using pip:
-```
-python 3 -m pip install requests
-```
-
-If you don't have pip installed, you can get it [here](https://pypi.org/project/pip/).
-
-## Installation
+## Quickstart
 1. Clone this repo
 ```sh
 git clone https://github.com/holbertonschool/W3C-Validator.git
 ```
 
-2. Run shell script (see example in [usage](#usage) section below)
-
-## Usage
+2. Run the validator command from within
 
 Single file:
 
@@ -42,3 +33,22 @@ Multiple files:
 ```
 
 All errors are printed in `STDERR`; Exit status = # of errors (0 on success)
+
+## Troubleshooting
+
+- Error: `bad interpreter: No such file or directory`
+If you get this error you might not have Python installed correctly; or the system [PATH](https://en.wikipedia.org/wiki/PATH_(variable)) might not be updated to reflect the installed Python version.
+
+Assuming that Python 3 is indeed installed, you can try to run it like so:
+```
+python3 w3c_validator.py index.html
+```
+- Error: `ModuleNotFoundError: No module named 'requests'`
+If you get this error you do not have the module `requests` installed in your system.
+
+You can install `requests` using pip:
+```
+python 3 -m pip install requests
+```
+
+If you don't have `pip` installed, you can get it [here](https://pypi.org/project/pip/).

--- a/w3c_validator.py
+++ b/w3c_validator.py
@@ -58,6 +58,10 @@ def __validate(file_path, type):
     d = open(file_path, "rb").read()
     u = "https://validator.w3.org/nu/?out=json"
     r = requests.post(u, headers=h, data=d)
+
+    if not r.status_code < 400:
+        raise ConnectionError("Unable to connect to API endpoint.")
+
     res = []
     messages = r.json().get('messages', [])
     for m in messages:

--- a/w3c_validator.py
+++ b/w3c_validator.py
@@ -46,7 +46,7 @@ def __print_stderr(msg):
     sys.stderr.buffer.write(msg.encode('utf-8'))
 
 
-def __validate(file_path, type="html"):
+def __validate(file_path, type):
     """
     Start validation of files
     """
@@ -57,7 +57,6 @@ def __validate(file_path, type="html"):
     r = requests.post(u, headers=h, data=d)
     res = []
     messages = r.json().get('messages', [])
-    
     for m in messages:
         # Capture files that have incomplete or broken HTML
         if m['type'] == 'error' or m['type'] == 'info':
@@ -80,7 +79,7 @@ def __analyse(file_path):
 
         if file_path.endswith(".css"):
             result = __validate(file_path, "text/css")
-        elif file_path.endswith((".html", "htm")):
+        elif file_path.endswith((".html", ".htm")):
             result = __validate(file_path, "text/html")
         elif file_path.endswith(".svg"):
             result = __validate(file_path, "image/svg+xml")

--- a/w3c_validator.py
+++ b/w3c_validator.py
@@ -4,11 +4,8 @@ W3C validator for Holberton School
 
 For HTML and CSS files.
 
-Based on 2 APIs:
-
+Based on 1 API:
 - https://validator.w3.org/docs/api.html
-- https://jigsaw.w3.org/css-validator/api.html
-
 
 Usage:
 
@@ -46,12 +43,18 @@ def __print_stderr(msg):
     sys.stderr.buffer.write(msg.encode('utf-8'))
 
 
+def __is_empty(file):
+    if os.path.getsize(file) == 0:
+        raise OSError("File '{}' is empty.".format(file))
+
+
 def __validate(file_path, type):
     """
     Start validation of files
     """
     h = {'Content-Type': "{}; charset=utf-8".format(type)}
-    # Open files in binary mode => https://requests.readthedocs.io/en/master/user/advanced/
+    # Open files in binary mode:
+    # https://requests.readthedocs.io/en/master/user/advanced/
     d = open(file_path, "rb").read()
     u = "http://localhost:8888/?out=json"
     r = requests.post(u, headers=h, data=d)
@@ -60,7 +63,7 @@ def __validate(file_path, type):
     for m in messages:
         # Capture files that have incomplete or broken HTML
         if m['type'] == 'error' or m['type'] == 'info':
-            res.append("[{}] {}".format(file_path, m['message']))
+            res.append("'{}' => {}".format(file_path, m['message']))
         else:
             res.append("[{}:{}] {}".format(
                 file_path, m['lastLine'], m['message']))
@@ -74,31 +77,31 @@ def __analyse(file_path):
     try:
         result = None
 
-        if os.path.getsize(file_path) == 0:
-            raise OSError(f"File {file_path} is empty")
-
         if file_path.endswith(".css"):
+            __is_empty(file_path)
             result = __validate(file_path, "text/css")
         elif file_path.endswith((".html", ".htm")):
+            __is_empty(file_path)
             result = __validate(file_path, "text/html")
         elif file_path.endswith(".svg"):
+            __is_empty(file_path)
             result = __validate(file_path, "image/svg+xml")
         else:
             allowed_files = "'.css', '.html', '.htm' and '.svg'"
             raise OSError(
-                "File {} does not have a valid file extension. Only {} are "
+                "File {} does not have a valid file extension.\nOnly {} are "
                 "allowed.".format(file_path, allowed_files)
-                )
+            )
 
         if len(result) > 0:
             for msg in result:
                 __print_stderr("{}\n".format(msg))
                 nb_errors += 1
         else:
-            __print_stdout("{} => OK\n".format(file_path))
+            __print_stdout("'{}' => OK\n".format(file_path))
 
     except Exception as e:
-        __print_stderr("[{}] {}\n".format(e.__class__.__name__, e))
+        __print_stderr("'{}' => {}\n".format(e.__class__.__name__, e))
     return nb_errors
 
 

--- a/w3c_validator.py
+++ b/w3c_validator.py
@@ -56,7 +56,7 @@ def __validate(file_path, type):
     # Open files in binary mode:
     # https://requests.readthedocs.io/en/master/user/advanced/
     d = open(file_path, "rb").read()
-    u = "http://localhost:8888/?out=json"
+    u = "https://validator.w3.org/nu/?out=json"
     r = requests.post(u, headers=h, data=d)
     res = []
     messages = r.json().get('messages', [])


### PR DESCRIPTION
@papamuziko after some research, I found that we could use the same validator API endpoint to check for HTML, CSS and SVG files.